### PR TITLE
Allow srcs to be provided the standard way

### DIFF
--- a/tasks/text-replace.js
+++ b/tasks/text-replace.js
@@ -19,8 +19,13 @@ module.exports = function(grunt) {
     'General purpose text replacement for grunt. Allows you to replace ' +
     'text in files using strings, regexs or functions.',
     function () {
+	  var srcs = this.data.src;
+	  if (!srcs && this.data.files)
+        srcs = Array.prototype.concat.apply([], this.data.files.map(function(filesHash){
+          return filesHash.src
+        }));
       gruntTextReplace.replace({
-        src: this.data.src,
+        src: srcs,
         dest: this.data.dest,
         overwrite: this.data.overwrite,
         replacements: this.data.replacements


### PR DESCRIPTION
Srcs can be retrieved from either config.src or config.files[..].src.
This allow grunt-text-replace to support the [Files Array Format](https://gruntjs.com/configuring-tasks#files-array-format) and the [Compact Format](https://gruntjs.com/configuring-tasks#compact-format). The Files Array Format is used by https://www.npmjs.com/package/grunt-changed, so text-replace wasn't able to handle files outputed by grunt-changed